### PR TITLE
Test environment configuration

### DIFF
--- a/az-avd_test.go
+++ b/az-avd_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/desktopvirtualization/armdesktopvirtualization"
 	"github.com/appliedres/cloudy"
 
-	//_ "github.com/appliedres/cloudy-azure"
 	"github.com/appliedres/cloudy/testutil"
 	"github.com/stretchr/testify/assert"
 )

--- a/az-credentials_test.go
+++ b/az-credentials_test.go
@@ -1,0 +1,32 @@
+package cloudyazure
+
+import (
+	"testing"
+
+	"github.com/appliedres/cloudy"
+	"github.com/appliedres/cloudy/testutil"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestReadFromEnv(t *testing.T) {
+	_ = testutil.LoadEnv("../arkloud-conf/arkloud.env")
+	env := cloudy.CreateCompleteEnvironment("ARKLOUD_ENV", "USERAPI_PREFIX", "KEYVAULT")
+	cloudy.SetDefaultEnvironment(env)
+
+	ctx = cloudy.StartContext()
+	tenantId = env.Force("AZ_TENANT_ID")
+	clientId = env.Force("AZ_CLIENT_ID")
+	clientSecret = env.Force("AZ_CLIENT_SECRET")
+	vaultUrl = env.Force("AZ_REGION")
+
+	azureCredentialLoader := AzureCredentialLoader{}
+	azureCredentialInterface := azureCredentialLoader.ReadFromEnv(env)
+	assert.NotNil(t, azureCredentialInterface)
+
+	actual := azureCredentialInterface.(AzureCredentials)
+	assert.NotNil(t, actual)
+	assert.EqualValues(t, tenantId, actual.TenantID)
+	assert.EqualValues(t, clientId, actual.ClientID)
+	assert.EqualValues(t, clientSecret, actual.ClientSecret)
+	assert.EqualValues(t, vaultUrl, actual.Region)
+}

--- a/az-vm-create_test.go
+++ b/az-vm-create_test.go
@@ -14,10 +14,13 @@ import (
 )
 
 func TestLinuxVMCreate(t *testing.T) {
+	_ = testutil.LoadEnv("../arkloud-conf/arkloud.env")
+
+	newEnv := cloudy.CreateCompleteEnvironment("ARKLOUD_ENV", "USERAPI_PREFIX", "KEYVAULT")
+	cloudy.SetDefaultEnvironment(newEnv)
 	ctx := cloudy.StartContext()
 
-	_ = testutil.LoadEnv("test.env")
-	vaultUrl := cloudy.ForceEnv("AZ_VAULT_URL", "")
+	vaultUrl := newEnv.Force("AZ_VAULT_URL")
 	creds := GetAzureCredentialsFromEnv(cloudy.DefaultEnvironment)
 
 	kve, _ := NewKeyVaultEnvironmentService(ctx, vaultUrl, creds, "")
@@ -100,19 +103,21 @@ func TestLinuxVMCreate(t *testing.T) {
 
 	// Test subnet
 	// subnet, err := vmc.FindBestSubnet(ctx, []string{"go-on-azure-vmSubnet"})
-	assert.Nil(t, err)
-	assert.NotEqual(t, "", subnet)
+	//assert.Nil(t, err)
+	//assert.NotEqual(t, "", subnet)
 
 	assert.NotNil(t, vmConfig.Size)
 
 	// Test Create NIC
 	err = vmc.CreateNIC(ctx, vmConfig, subnet)
 	assert.Nil(t, err)
-	assert.NotNil(t, vmConfig.PrimaryNetwork)
+	assert.NotNil(t, vmConfig.PrimaryNetwork, "Primary Network not configured, no futher testing possible")
+	if vmConfig.PrimaryNetwork == nil {
+		return
+	}
 	assert.NotNil(t, vmConfig.PrimaryNetwork.ID)
 	assert.NotNil(t, vmConfig.PrimaryNetwork.Name)
 	assert.NotNil(t, vmConfig.PrimaryNetwork.PrivateIP)
-
 	defer vmc.DeleteNIC(ctx, vmConfig.ID, vmConfig.PrimaryNetwork.Name)
 
 	// Test Create
@@ -220,6 +225,11 @@ func TestWindowsVMCreate(t *testing.T) {
 	err = vmc.CreateNIC(ctx, vmConfig, subnet)
 	assert.Nil(t, err)
 	assert.NotNil(t, vmConfig.PrimaryNetwork)
+	assert.NotNil(t, vmConfig.PrimaryNetwork, "Primary Network not configured, no futher testing possible")
+	if vmConfig.PrimaryNetwork == nil {
+		return
+	}
+
 	assert.NotNil(t, vmConfig.PrimaryNetwork.ID)
 	assert.NotNil(t, vmConfig.PrimaryNetwork.Name)
 	assert.NotNil(t, vmConfig.PrimaryNetwork.PrivateIP)

--- a/az-vm-sizes_test.go
+++ b/az-vm-sizes_test.go
@@ -1,0 +1,72 @@
+package cloudyazure
+
+import (
+	// "crypto/x509"
+	// "encoding/pem"
+	// "fmt"
+	"testing"
+
+	"github.com/appliedres/cloudy"
+	"github.com/appliedres/cloudy/testutil"
+	"github.com/stretchr/testify/assert"
+	// "golang.org/x/crypto/ssh"
+)
+
+func TestLoad(t *testing.T) {
+	_ = testutil.LoadEnv("../arkloud-conf/arkloud.env")
+
+	newEnv := cloudy.CreateCompleteEnvironment("ARKLOUD_ENV", "USERAPI_PREFIX", "KEYVAULT")
+	cloudy.SetDefaultEnvironment(newEnv)
+	ctx := cloudy.StartContext()
+
+	vaultUrl := newEnv.Force("AZ_VAULT_URL")
+	creds := GetAzureCredentialsFromEnv(cloudy.DefaultEnvironment)
+
+	kve, _ := NewKeyVaultEnvironmentService(ctx, vaultUrl, creds, "")
+
+	env := cloudy.NewTieredEnvironment(
+		cloudy.NewTestFileEnvironmentService(),
+		kve,
+	)
+
+	ctx = cloudy.StartContext()
+	tenantID, _ := env.Get("AZ_TENANT_ID")
+	ClientID, _ := env.Get("AZ_CLIENT_ID")
+	ClientSecret, _ := env.Get("AZ_CLIENT_SECRET")
+	SubscriptionID, _ := env.Get("AZ_SUBSCRIPTION_ID")
+	resourceGroup, _ := env.Get("AZ_RESOURCE_GROUP")
+	vNet, _ := env.Get("AZ_VNET")
+	subnet, _ := env.Get("AZ_SUBNET")
+	nsgName, _ := env.Get("AZ_NSG_NAME")
+	imageGallery, _ := env.Get("VMC_AZ_SOURCE_IMAGE_GALLERY_NAME")
+
+	vmc, err := NewAzureVMController(ctx, &AzureVMControllerConfig{
+		AzureCredentials: AzureCredentials{
+			TenantID:     tenantID,
+			ClientID:     ClientID,
+			ClientSecret: ClientSecret,
+			Region:       "usgovvirginia",
+		},
+
+		SubscriptionID: SubscriptionID,
+
+		ResourceGroup:            resourceGroup,
+		NetworkResourceGroup:     resourceGroup,
+		SourceImageGalleryName:   imageGallery,
+		Vnet:                     vNet,
+		AvailableSubnets:         []string{subnet},
+		NetworkSecurityGroupName: nsgName,
+		NetworkSecurityGroupID:   "NOT SET",
+		VaultURL:                 vaultUrl,
+	})
+	assert.Nil(t, err)
+
+	cache := &AzureVMSizeCache{}
+	loaded := cache.Load(ctx, vmc)
+	assert.NotNil(t, cache)
+	assert.Nil(t, loaded)
+}
+
+func TestMerge(t *testing.T) {
+	// NOOP - Merge has no implementation
+}

--- a/azure-documentdb-storage.go
+++ b/azure-documentdb-storage.go
@@ -2,6 +2,7 @@ package cloudyazure
 
 import (
 	"context"
+	"errors"
 
 	"github.com/appliedres/cloudy/datastore"
 )
@@ -34,15 +35,24 @@ func (az *AzureCosmosDbDatastore) Close(ctx context.Context) error {
 // The key is used as the ID for the document and is required to be unique
 // for this index
 func (az *AzureCosmosDbDatastore) Save(ctx context.Context, item interface{}, key string) error {
+	if az.DB == nil {
+		return errors.New("DB Connection not established")
+	}
 	return az.DB.Upsert(key, item)
 }
 
 func (az *AzureCosmosDbDatastore) Get(ctx context.Context, key string) (interface{}, error) {
+	if az.DB == nil {
+		return nil, errors.New("DB Connection not established")
+	}
 	rtn, err := az.DB.Get(key)
 	return rtn, err
 }
 
 func (az *AzureCosmosDbDatastore) GetAll(ctx context.Context) ([]interface{}, error) {
+	if az.DB == nil {
+		return nil, errors.New("DB Connection not established")
+	}
 	rtn, err := az.DB.GetAll()
 	return rtn, err
 }
@@ -53,6 +63,9 @@ func (az *AzureCosmosDbDatastore) Exists(ctx context.Context, key string) (bool,
 }
 
 func (az *AzureCosmosDbDatastore) Delete(ctx context.Context, key string) error {
+	if az.DB == nil {
+		return errors.New("DB Connection not established")
+	}
 	err := az.DB.Remove(key)
 	return err
 }
@@ -62,5 +75,8 @@ func (az *AzureCosmosDbDatastore) Ping(ctx context.Context) bool {
 }
 
 func (az *AzureCosmosDbDatastore) Query(ctx context.Context, query *datastore.SimpleQuery) ([]interface{}, error) {
+	if az.DB == nil {
+		return nil, errors.New("DB Connection not established")
+	}
 	return nil, nil
 }

--- a/azure-documentdb-storage_test.go
+++ b/azure-documentdb-storage_test.go
@@ -1,0 +1,215 @@
+package cloudyazure
+
+import (
+	"testing"
+
+	"github.com/appliedres/cloudy"
+	"github.com/appliedres/cloudy/testutil"
+	"github.com/stretchr/testify/assert"
+)
+
+var (
+	// bad DB connection config
+	badDbConnection = AzureCosmosDbDatastore{
+		url: "https://badurl.com",
+		key: "food",
+	}
+)
+
+func TestOpen(t *testing.T) {
+
+	_ = testutil.LoadEnv("../arkloud-conf/arkloud.env")
+
+	newEnv := cloudy.CreateCompleteEnvironment("ARKLOUD_ENV", "USERAPI_PREFIX", "KEYVAULT")
+	cloudy.SetDefaultEnvironment(newEnv)
+	ctx := cloudy.StartContext()
+
+	vaultUrl := newEnv.Force("AZ_VAULT_URL")
+	creds := GetAzureCredentialsFromEnv(cloudy.DefaultEnvironment)
+
+	kve, _ := NewKeyVaultEnvironmentService(ctx, vaultUrl, creds, "")
+
+	_ = cloudy.NewTieredEnvironment(
+		cloudy.NewTestFileEnvironmentService(),
+		kve,
+	)
+
+	ctx = cloudy.StartContext()
+
+	var a interface{}
+	assert.Nil(t, badDbConnection.Open(ctx, a))
+}
+
+func TestClose(t *testing.T) {
+
+	_ = testutil.LoadEnv("../arkloud-conf/arkloud.env")
+
+	newEnv := cloudy.CreateCompleteEnvironment("ARKLOUD_ENV", "USERAPI_PREFIX", "KEYVAULT")
+	cloudy.SetDefaultEnvironment(newEnv)
+	ctx := cloudy.StartContext()
+
+	vaultUrl := newEnv.Force("AZ_VAULT_URL")
+	creds := GetAzureCredentialsFromEnv(cloudy.DefaultEnvironment)
+
+	kve, _ := NewKeyVaultEnvironmentService(ctx, vaultUrl, creds, "")
+
+	_ = cloudy.NewTieredEnvironment(
+		cloudy.NewTestFileEnvironmentService(),
+		kve,
+	)
+
+	ctx = cloudy.StartContext()
+
+	assert.Nil(t, badDbConnection.Close(ctx))
+}
+
+func TestSave(t *testing.T) {
+
+	_ = testutil.LoadEnv("../arkloud-conf/arkloud.env")
+
+	newEnv := cloudy.CreateCompleteEnvironment("ARKLOUD_ENV", "USERAPI_PREFIX", "KEYVAULT")
+	cloudy.SetDefaultEnvironment(newEnv)
+	ctx := cloudy.StartContext()
+
+	vaultUrl := newEnv.Force("AZ_VAULT_URL")
+	creds := GetAzureCredentialsFromEnv(cloudy.DefaultEnvironment)
+
+	kve, _ := NewKeyVaultEnvironmentService(ctx, vaultUrl, creds, "")
+
+	_ = cloudy.NewTieredEnvironment(
+		cloudy.NewTestFileEnvironmentService(),
+		kve,
+	)
+
+	ctx = cloudy.StartContext()
+
+	var a interface{}
+	key := "key"
+	assert.NotNil(t, badDbConnection.Save(ctx, a, key))
+}
+
+func TestGet(t *testing.T) {
+
+	_ = testutil.LoadEnv("../arkloud-conf/arkloud.env")
+
+	newEnv := cloudy.CreateCompleteEnvironment("ARKLOUD_ENV", "USERAPI_PREFIX", "KEYVAULT")
+	cloudy.SetDefaultEnvironment(newEnv)
+	ctx := cloudy.StartContext()
+
+	vaultUrl := newEnv.Force("AZ_VAULT_URL")
+	creds := GetAzureCredentialsFromEnv(cloudy.DefaultEnvironment)
+
+	kve, _ := NewKeyVaultEnvironmentService(ctx, vaultUrl, creds, "")
+
+	_ = cloudy.NewTieredEnvironment(
+		cloudy.NewTestFileEnvironmentService(),
+		kve,
+	)
+
+	ctx = cloudy.StartContext()
+
+	badKey := "key"
+	rtn, error := badDbConnection.Get(ctx, badKey)
+	assert.Nil(t, rtn)
+	assert.NotNil(t, error)
+}
+
+func TestGetAll(t *testing.T) {
+
+	_ = testutil.LoadEnv("../arkloud-conf/arkloud.env")
+
+	newEnv := cloudy.CreateCompleteEnvironment("ARKLOUD_ENV", "USERAPI_PREFIX", "KEYVAULT")
+	cloudy.SetDefaultEnvironment(newEnv)
+	ctx := cloudy.StartContext()
+
+	vaultUrl := newEnv.Force("AZ_VAULT_URL")
+	creds := GetAzureCredentialsFromEnv(cloudy.DefaultEnvironment)
+
+	kve, _ := NewKeyVaultEnvironmentService(ctx, vaultUrl, creds, "")
+
+	_ = cloudy.NewTieredEnvironment(
+		cloudy.NewTestFileEnvironmentService(),
+		kve,
+	)
+
+	ctx = cloudy.StartContext()
+
+	rtn, error := badDbConnection.GetAll(ctx)
+	assert.Nil(t, rtn)
+	assert.NotNil(t, error)
+}
+
+func TestExists(t *testing.T) {
+
+	_ = testutil.LoadEnv("../arkloud-conf/arkloud.env")
+
+	newEnv := cloudy.CreateCompleteEnvironment("ARKLOUD_ENV", "USERAPI_PREFIX", "KEYVAULT")
+	cloudy.SetDefaultEnvironment(newEnv)
+	ctx := cloudy.StartContext()
+
+	vaultUrl := newEnv.Force("AZ_VAULT_URL")
+	creds := GetAzureCredentialsFromEnv(cloudy.DefaultEnvironment)
+
+	kve, _ := NewKeyVaultEnvironmentService(ctx, vaultUrl, creds, "")
+
+	_ = cloudy.NewTieredEnvironment(
+		cloudy.NewTestFileEnvironmentService(),
+		kve,
+	)
+
+	ctx = cloudy.StartContext()
+
+	badKey := "key"
+	rtn, error := badDbConnection.Get(ctx, badKey)
+	assert.Nil(t, rtn)
+	assert.NotNil(t, error)
+}
+
+func TestDelete(t *testing.T) {
+
+	_ = testutil.LoadEnv("../arkloud-conf/arkloud.env")
+
+	newEnv := cloudy.CreateCompleteEnvironment("ARKLOUD_ENV", "USERAPI_PREFIX", "KEYVAULT")
+	cloudy.SetDefaultEnvironment(newEnv)
+	ctx := cloudy.StartContext()
+
+	vaultUrl := newEnv.Force("AZ_VAULT_URL")
+	creds := GetAzureCredentialsFromEnv(cloudy.DefaultEnvironment)
+
+	kve, _ := NewKeyVaultEnvironmentService(ctx, vaultUrl, creds, "")
+
+	_ = cloudy.NewTieredEnvironment(
+		cloudy.NewTestFileEnvironmentService(),
+		kve,
+	)
+
+	ctx = cloudy.StartContext()
+
+	badKey := "key"
+	error := badDbConnection.Delete(ctx, badKey)
+	assert.NotNil(t, error)
+}
+
+func TestPing(t *testing.T) {
+
+	_ = testutil.LoadEnv("../arkloud-conf/arkloud.env")
+
+	newEnv := cloudy.CreateCompleteEnvironment("ARKLOUD_ENV", "USERAPI_PREFIX", "KEYVAULT")
+	cloudy.SetDefaultEnvironment(newEnv)
+	ctx := cloudy.StartContext()
+
+	vaultUrl := newEnv.Force("AZ_VAULT_URL")
+	creds := GetAzureCredentialsFromEnv(cloudy.DefaultEnvironment)
+
+	kve, _ := NewKeyVaultEnvironmentService(ctx, vaultUrl, creds, "")
+
+	_ = cloudy.NewTieredEnvironment(
+		cloudy.NewTestFileEnvironmentService(),
+		kve,
+	)
+
+	ctx = cloudy.StartContext()
+
+	rtn := badDbConnection.Ping(ctx)
+	assert.False(t, rtn)
+}

--- a/keyvault-environment_test.go
+++ b/keyvault-environment_test.go
@@ -10,10 +10,14 @@ import (
 )
 
 func setUpKVE() (context.Context, *KeyVaultEnvironment, error) {
+	_ = testutil.LoadEnv("../arkloud-conf/arkloud.env")
+	env := cloudy.CreateCompleteEnvironment("ARKLOUD_ENV", "USERAPI_PREFIX", "KEYVAULT")
+	cloudy.SetDefaultEnvironment(env)
+
+	subscriptionId = env.Force("AZ_SUBSCRIPTION_ID")
+	vaultUrl = env.Force("AZ_VAULT_URL")
 
 	ctx := cloudy.StartContext()
-	_ = testutil.LoadEnv("test.env")
-	vaultUrl := cloudy.ForceEnv("AZ_VAULT_URL", "")
 	creds := GetAzureCredentialsFromEnv(cloudy.DefaultEnvironment)
 
 	kve, err := NewKeyVaultEnvironmentService(ctx, vaultUrl, creds, "")
@@ -22,7 +26,12 @@ func setUpKVE() (context.Context, *KeyVaultEnvironment, error) {
 }
 
 func TestProvider(t *testing.T) {
-	_ = testutil.LoadEnv("test.env")
+	_ = testutil.LoadEnv("../arkloud-conf/arkloud.env")
+	env := cloudy.CreateCompleteEnvironment("ARKLOUD_ENV", "USERAPI_PREFIX", "KEYVAULT")
+	cloudy.SetDefaultEnvironment(env)
+
+	subscriptionId = env.Force("AZ_SUBSCRIPTION_ID")
+	vaultUrl = env.Force("AZ_VAULT_URL")
 
 	normal, err := cloudy.EnvironmentProviders.NewFromEnvWith(cloudy.DefaultEnvironment, KeyVaultId)
 	assert.Nilf(t, err, "Error, %v", err)

--- a/keyvault_test.go
+++ b/keyvault_test.go
@@ -12,12 +12,16 @@ import (
 func TestKeyVault(t *testing.T) {
 
 	_ = testutil.LoadEnv("../arkloud-conf/arkloud.env")
+	env := cloudy.CreateCompleteEnvironment("ARKLOUD_ENV", "USERAPI_PREFIX", "KEYVAULT")
+	cloudy.SetDefaultEnvironment(env)
+
+	tenantID := env.Force("AZ_TENANT_ID")
+	ClientID := env.Force("AZ_CLIENT_ID")
+	ClientSecret := env.Force("AZ_CLIENT_SECRET")
+	subscriptionId = env.Force("AZ_SUBSCRIPTION_ID")
+	vaultUrl = env.Force("AZ_VAULT_URL")
 
 	ctx := cloudy.StartContext()
-
-	tenantID := cloudy.ForceEnv("KEYVAULT_AZ_TENANT_ID", "")
-	ClientID := cloudy.ForceEnv("KEYVAULT_AZ_CLIENT_ID", "")
-	ClientSecret := cloudy.ForceEnv("KEYVAULT_AZ_CLIENT_SECRET", "")
 
 	creds := AzureCredentials{
 		TenantID:     tenantID,

--- a/storage-blob_test.go
+++ b/storage-blob_test.go
@@ -10,10 +10,14 @@ import (
 )
 
 func TestBlobAccount(t *testing.T) {
+	_ = testutil.LoadEnv("../arkloud-conf/arkloud.env")
+	env := cloudy.CreateCompleteEnvironment("ARKLOUD_ENV", "USERAPI_PREFIX", "KEYVAULT")
+	cloudy.SetDefaultEnvironment(env)
+
 	ctx := cloudy.StartContext()
 	_ = testutil.LoadEnv("test.env")
-	account := cloudy.ForceEnv("account_blob", "")
-	accountKey := cloudy.ForceEnv("account_blob_Key", "")
+	account := env.Force("ACCOUNT_BLOB")
+	accountKey := env.Force("ACCOUNT_BLOB_KEY")
 
 	bsa, err := NewBlobStorageAccount(ctx, account, accountKey, "")
 	if err != nil {
@@ -26,10 +30,14 @@ func TestBlobAccount(t *testing.T) {
 }
 
 func TestBlobFileAccount(t *testing.T) {
+	_ = testutil.LoadEnv("../arkloud-conf/arkloud.env")
+	env := cloudy.CreateCompleteEnvironment("ARKLOUD_ENV", "USERAPI_PREFIX", "KEYVAULT")
+	cloudy.SetDefaultEnvironment(env)
+
 	ctx := cloudy.StartContext()
 	_ = testutil.LoadEnv("test.env")
-	account := cloudy.ForceEnv("accountBlob", "")
-	accountKey := cloudy.ForceEnv("accountBlobKey", "")
+	account := env.Force("ACCOUNT_BLOB")
+	accountKey := env.Force("ACCOUNT_BLOB_KEY")
 
 	bfa, err := NewBlobContainerShare(ctx, account, accountKey, "")
 	if err != nil {

--- a/storage-fileshare_test.go
+++ b/storage-fileshare_test.go
@@ -9,14 +9,20 @@ import (
 )
 
 func TestBlobFileshare(t *testing.T) {
-	ctx := cloudy.StartContext()
-	_ = testutil.LoadEnv("test.env")
-	tenantID := cloudy.ForceEnv("TenantID", "")
-	ClientID := cloudy.ForceEnv("ClientID", "")
-	ClientSecret := cloudy.ForceEnv("ClientSecret", "")
-	account := cloudy.ForceEnv("fsAccount", "")
-	resourceGroup := cloudy.ForceEnv("rgFileshare", "")
-	subscriptionId := cloudy.ForceEnv("SUBSCRIPTION_ID", "")
+
+	_ = testutil.LoadEnv("../arkloud-conf/arkloud.env")
+	env := cloudy.CreateCompleteEnvironment("ARKLOUD_ENV", "USERAPI_PREFIX", "KEYVAULT")
+	cloudy.SetDefaultEnvironment(env)
+
+	ctx = cloudy.StartContext()
+	tenantID := env.Force("AZ_TENANT_ID")
+	ClientID := env.Force("AZ_CLIENT_ID")
+	ClientSecret := env.Force("AZ_CLIENT_SECRET")
+	subscriptionId := env.Force("AZ_SUBSCRIPTION_ID")
+	vaultUrl = env.Force("AZ_VAULT_URL")
+
+	account := env.Force("FS_ACCOUNT")
+	resourceGroup := env.Force("RG_FILESHARE")
 
 	creds := AzureCredentials{
 		TenantID:     tenantID,
@@ -27,8 +33,8 @@ func TestBlobFileshare(t *testing.T) {
 	bfa, err := NewBlobFileShare(ctx, &BlobFileShare{
 		Credentials:        creds,
 		StorageAccountName: account,
-		ResourceGroupName: resourceGroup,
-		SubscriptionID:    subscriptionId,
+		ResourceGroupName:  resourceGroup,
+		SubscriptionID:     subscriptionId,
 	})
 	if err != nil {
 		log.Fatal(err)

--- a/vm-status_test.go
+++ b/vm-status_test.go
@@ -10,14 +10,19 @@ import (
 )
 
 func TestAllVMStatus(t *testing.T) {
-	ctx := cloudy.StartContext()
-	_ = testutil.LoadEnv("test.env")
+	_ = testutil.LoadEnv("../arkloud-conf/arkloud.env")
+	env := cloudy.CreateCompleteEnvironment("ARKLOUD_ENV", "USERAPI_PREFIX", "KEYVAULT")
+	cloudy.SetDefaultEnvironment(env)
 
-	tenantID := cloudy.ForceEnv("AZ_TENANT_ID", "")
-	ClientID := cloudy.ForceEnv("AZ_CLIENT_ID", "")
-	ClientSecret := cloudy.ForceEnv("AZ_CLIENT_SECRET", "")
-	resourceGroup := cloudy.ForceEnv("AZ_RESOURCE_GROUP", "")
-	SubscriptionID := cloudy.ForceEnv("AZ_SUBSCRIPTION_ID", "")
+	ctx = cloudy.StartContext()
+	tenantID := env.Force("AZ_TENANT_ID")
+	ClientID := env.Force("AZ_CLIENT_ID")
+	ClientSecret := env.Force("AZ_CLIENT_SECRET")
+	SubscriptionID := env.Force("AZ_SUBSCRIPTION_ID")
+
+	vaultUrl = env.Force("AZ_VAULT_URL")
+
+	resourceGroup := env.Force("AZ_RESOURCE_GROUP")
 
 	vmc, err := NewAzureVMController(ctx, &AzureVMControllerConfig{
 		AzureCredentials: AzureCredentials{


### PR DESCRIPTION
NOTE:  The following env vars are required in the arkloud/arkloud-conf/arkloud.env file for all tests to run.

Settings in **BOLD** are new to the arkloud.env.

KEYVAULT_AZ_CLIENT_SECRET=
KEYVAULT_AZ_CLIENT_ID=
KEYVAULT_AZ_TENANT_ID=
AZ_VAULT_URL=
ARKLOUD_ENV=
USERAPI_PREFIX=

DATATYPE_USER=
DATATYPE_PASSWORD=
DATATYPE_HOST=
DATATYPE_DATABASE=

TEST_USER=
TEST_SKU=     # Use  SKU for Office 365

**ACCOUNT_BLOB=""
ACCOUNT_BLOB_KEY=""
FS_ACCOUNT=""
RG_FILESHARE=""
AZ_RESOURCE_GROUP=""**

#### What does this PR do?
modifies tests to use hierarchical env resolution

Also adds a number of test conditions to catch nil pointer dereferencing errors that were causing tests to abort prematurely

 
##### Who is reviewing it?
@wflentje 
 
 
##### How should this be tested?
Note: Requires the cloudy ( https://github.com/appliedres/cloudy ) API from 15 Mar 2023
 
Pull code. 

Configure arkloud/arkloud-conf/arkloud.env with env vars mentiooned above.run 

| go test.

Tests will fail, but they will initialize and run.


